### PR TITLE
Fix MCP session header propagation for parallel reasoning sessions

### DIFF
--- a/src/workers/everything-workers.ts
+++ b/src/workers/everything-workers.ts
@@ -190,7 +190,8 @@ const EXAMPLE_COMPLETIONS = {
 
 export const createServer = (
   parallelReasoningSessions?: Map<string, ParallelReasoningSession>,
-  persistCallback?: () => Promise<void>
+  persistCallback?: () => Promise<void>,
+  getTransportSessionId?: () => string | null | undefined
 ) => {
   // Initialize parallel reasoning session store if not provided
   const sessionStore = parallelReasoningSessions || new Map<string, ParallelReasoningSession>();
@@ -979,7 +980,11 @@ Use these tools to enable Grok 4 Heavy / GPT-5 Pro style parallel compute:
     // Parallel Reasoning Tool Handlers
     if (name === ParallelReasoningToolName.PARALLEL_REASONING_INIT) {
       const validatedArgs = ParallelReasoningInitSchema.parse(args);
-      const result = handleParallelReasoningInit(validatedArgs, sessionStore);
+      const result = handleParallelReasoningInit(
+        validatedArgs,
+        sessionStore,
+        getTransportSessionId
+      );
       // Persist after state change
       if (persistCallback) await persistCallback();
       return result;

--- a/src/workers/parallel-reasoning-tools.ts
+++ b/src/workers/parallel-reasoning-tools.ts
@@ -82,9 +82,11 @@ export enum ParallelReasoningToolName {
 
 export function handleParallelReasoningInit(
   args: z.infer<typeof ParallelReasoningInitSchema>,
-  sessionStore: Map<string, ParallelReasoningSession>
+  sessionStore: Map<string, ParallelReasoningSession>,
+  getTransportSessionId?: () => string | null | undefined
 ): any {
-  const sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  const transportSessionId = getTransportSessionId?.() ?? null;
+  const sessionId = transportSessionId ?? `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
   const session = initializeSession(
     sessionId,
@@ -101,7 +103,7 @@ export function handleParallelReasoningInit(
   const agentPrompts = getAgentPrompts(session);
   
   // Return response with session_id prominently displayed
-  const responseData = {
+  const responseData: Record<string, unknown> = {
     session_id: sessionId,
     task: args.task,
     agent_count: session.agent_count,
@@ -130,6 +132,15 @@ ${a.prompt}
 ⚡ Start reasoning in parallel now!
     `.trim()
   };
+
+  if (transportSessionId) {
+    responseData.transport_session_id = transportSessionId;
+    responseData.instructions += `
+
+🛰️ **Session Routing**:
+- Use the provided session_id for tool arguments
+- The MCP client should reuse the \`mcp-session-id\` header value (${transportSessionId}) for all subsequent requests`;
+  }
 
   return {
     content: [

--- a/src/workers/session.ts
+++ b/src/workers/session.ts
@@ -78,7 +78,8 @@ export class MCPSession extends DurableObject {
       };
       const { server, cleanup, startNotificationIntervals } = createServer(
         this.parallelReasoningSessions,
-        persistCallback
+        persistCallback,
+        () => this.sessionId
       );
       this.server = server;
       this.cleanup = cleanup;
@@ -122,7 +123,8 @@ export class MCPSession extends DurableObject {
       this.startHeartbeat();
 
       // Return the response
-      return await expressRes.toResponse();
+      const response = await expressRes.toResponse();
+      return this.attachSessionHeader(response);
     }
 
     // Existing session - handle the request
@@ -148,7 +150,8 @@ export class MCPSession extends DurableObject {
 
     await this.transport!.handleRequest(expressReq as any, expressRes as any, expressReq.body);
 
-    return await expressRes.toResponse();
+    const response = await expressRes.toResponse();
+    return this.attachSessionHeader(response);
   }
 
   private async handleGet(request: Request): Promise<Response> {
@@ -183,7 +186,8 @@ export class MCPSession extends DurableObject {
 
     await this.transport.handleRequest(expressReq as any, expressRes as any, expressReq.body);
 
-    return await expressRes.toResponse();
+    const response = await expressRes.toResponse();
+    return this.attachSessionHeader(response);
   }
 
   private async handleDelete(request: Request): Promise<Response> {
@@ -212,7 +216,8 @@ export class MCPSession extends DurableObject {
 
       await this.transport.handleRequest(expressReq as any, expressRes as any, expressReq.body);
 
-      return await expressRes.toResponse();
+      const response = await expressRes.toResponse();
+      return this.attachSessionHeader(response);
     } catch (error) {
       console.error('Error handling session termination:', error);
       return new Response(JSON.stringify({
@@ -269,6 +274,21 @@ export class MCPSession extends DurableObject {
     if (sessions) {
       this.parallelReasoningSessions = new Map(sessions);
     }
+  }
+
+  private attachSessionHeader(response: Response): Response {
+    if (!this.sessionId) {
+      return response;
+    }
+
+    const headers = new Headers(response.headers);
+    headers.set('mcp-session-id', this.sessionId);
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the durable object always attaches the `mcp-session-id` header so clients can reconnect to the same session
- thread the transport session identifier through the server and parallel reasoning init response to expose the routing id to clients
- document the required header reuse in the parallel reasoning initialization instructions

## Testing
- npm run build --silent

------
https://chatgpt.com/codex/tasks/task_e_68db37089ab0833383bb638bfdb4d129